### PR TITLE
adds a 'headerClass' attribute 

### DIFF
--- a/js/bootstrap-modal-wrapper-factory.js
+++ b/js/bootstrap-modal-wrapper-factory.js
@@ -128,7 +128,8 @@
             closeByKeyboard: true,
             size: null,
             onDestroy: null,
-            buttons: []
+            buttons: [],
+            headerClass : null
         }, options);
 
         this.originalModal = null;
@@ -153,6 +154,10 @@
         }
         if (this.options.closable) {
             this.originalModal.find(".modal-header").append(modalHeaderClosableContainer);
+        }
+
+        if(this.options.headerClass) {
+            this.originalModal.find(".modal-header").addClass(this.options.headerClass);
         }
 
         if (this.options.message) {


### PR DESCRIPTION
adds a 'headerClass' attribute  so you can pass 'bg-primary' and other background Bootstrap 4 styles to the header.